### PR TITLE
refactor: mova o `Footer` para fora da tag main em `[tag].astro`

### DIFF
--- a/src/pages/tag/[tag].astro
+++ b/src/pages/tag/[tag].astro
@@ -43,9 +43,9 @@ const { tag } = Astro.params
                 <section>
                     <h3>Postagens marcadas com "{tag}"</h3>
                     <PostList posts={posts} sort />
-                    <Footer />
                 </section>
             </main>
+            <Footer />
         </Container>
         <ColorScript />
     </body>


### PR DESCRIPTION
Assim como em outras páginas, o Footer fica fora da tag main, porque ele não é considerado como conteúdo principal

Portanto, foi movido para fora e deixado no mesmo nível de Header e Navigation para contribuir na semântica e acessibilidade