### PR TITLE
chore: adicione `.gitattributes` para ignorar `.xsl` das estatísticas

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+public/rss/* linguist-vendored


### PR DESCRIPTION
Nas estatísticas do repositório colocava o 'XSLT' como a linguagem mais usada, mas isso se dava devido ao arquivo 'styles.xsl' que é mais pesado que todos os arquivos de 'src'

Por isso, foi adicionado o '.gitattributes' para ignorar todos os arquivos contidos em 'public/rss/'