### PR TITLE
feat: adicione botões que permita copiar os códigos facilmente

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -7,6 +7,7 @@ import Container from '~/components/Container.astro'
 import Header from '~/components/Header.astro'
 import { SITE_LANG } from '~/config'
 
+import CodeBlockScript from '../scripts/CodeBlockScript.astro'
 import ColorScript from '../scripts/ColorScript.astro'
 import BaseHead from '../components/BaseHead.astro'
 import TagList from '../components/TagList.astro'
@@ -55,5 +56,6 @@ const {
             <Footer />
         </Container>
         <ColorScript />
+        <CodeBlockScript />
     </body>
 </html>

--- a/src/scripts/CodeBlockScript.astro
+++ b/src/scripts/CodeBlockScript.astro
@@ -1,0 +1,41 @@
+<script is:inline>
+    ;(() => {
+        const ONE_SECOND = 1e3
+
+        function addButtons() {
+            const codeBlocks = Array.from(document.querySelectorAll('pre.astro-code'))
+
+            for (const codeBlock of codeBlocks) {
+                const button = document.createElement('button')
+                button.classList.add('copy-code-btn')
+
+                const language = codeBlock.getAttribute('data-language') || 'plaintext'
+                button.textContent = language
+
+                const code = codeBlock.getElementsByTagName('code')[0]
+
+                let timeout = null
+
+                button.onclick = () => {
+                    navigator.clipboard.writeText(code.textContent)
+
+                    button.setAttribute('data-copied', 'true')
+                    button.textContent = '✓ Copiado'
+
+                    if (timeout) {
+                        window.clearTimeout(timeout)
+                    }
+
+                    timeout = setTimeout(() => {
+                        button.setAttribute('data-copied', 'false')
+                        button.textContent = language
+                    }, ONE_SECOND)
+                }
+
+                codeBlock.appendChild(button)
+            }
+        }
+
+        addButtons()
+    })()
+</script>

--- a/src/style/global.css
+++ b/src/style/global.css
@@ -35,8 +35,10 @@
 @media (prefers-color-scheme: light) {
     :root {
         --border: 0 0% 80%;
-        --background: 0 0% 96%;
+        --background: 0 0% 98%;
         --foreground: 0 0% 9%;
+
+        --codeblock-border-opacity: 0.5;
 
         --tag: 240 3% 90%;
         --tag-foreground: 240, 4%, 16%;
@@ -55,6 +57,8 @@
         --border: 240 4% 18%;
         --background: 0 0% 9%;
         --foreground: 0 0% 96%;
+
+        --codeblock-border-opacity: 0;
 
         --tag: 240 4% 16%;
         --tag-foreground: 240 1% 81%;
@@ -99,6 +103,7 @@ strong {
 small {
     font-size: 80%;
 }
+
 a {
     color: inherit;
     text-underline-offset: 0.2ex;
@@ -107,7 +112,50 @@ a {
 
 pre {
     padding: 1rem;
+    margin: 0.25rem 0;
+
+    overflow: hidden;
+    position: relative;
+
     border-radius: 0.325rem;
+    border: 1px solid hsl(var(--border) / var(--codeblock-border-opacity));
+}
+
+code {
+    display: block;
+    overflow-x: auto;
+}
+
+button {
+    border: none;
+    font: inherit;
+    color: inherit;
+    display: inline-flex;
+    background-color: transparent;
+}
+
+.copy-code-btn {
+    position: absolute;
+    right: 0;
+    top: 0;
+
+    font-size: 0.75rem;
+    border-radius: 0.25rem;
+    color: hsl(var(--foreground) / 0.5);
+    background-color: hsl(var(--background) / 0.75);
+
+    margin: 0.25rem 0.5rem;
+    padding: 0.25rem 0.5rem;
+
+    cursor: pointer;
+}
+
+.copy-code-btn:hover {
+    color: hsl(var(--foreground));
+}
+
+.copy-code-btn[data-copied='true'] {
+    color: var(--green);
 }
 
 sub,


### PR DESCRIPTION
Para que o usuário copiasse os códigos contidos nas postagens era necessário selecionar e copiar manualmente

Portanto, foi criado um script que insere botões nos blocos de código que permite identificar a linguagem de programação e copiar o conteúdo interno