### PR TITLE
chore: configure um dev container para o projeto

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:13.2-slim
+
+ENV LANG=pt_BR.UTF-8
+ENV LANGUAGE=pt_BR.UTF-8
+ENV LC_ALL=pt_BR.UTF-8
+
+ENV BUN_INSTALL=/root/.bun
+ENV PATH="$BUN_INSTALL/bin:$PATH"
+
+RUN apt update && \
+    apt install -y git fish vim curl unzip locales locales-all && \
+    rm -rf /var/lib/apt/lists/* && \
+    git config --global editor.core vim
+
+RUN curl -fsSL https://bun.com/install | bash
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+    "build": {"dockerfile": "Dockerfile", "context": "."},
+    "workspaceFolder": "/workspaces/blog",
+    "forwardPorts": [4321]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@yur1freitas/blog",


### PR DESCRIPTION
Com o intuito de facilitar o desenvolvimento do projeto, foi criado uma configuração de um dev container contendo os pacotes necessários, como o bun, git, fish, vim e outros