### PR TITLE
fix: limite o tamanho das imagens para evitar transbordamento

### DIFF
--- a/src/style/global.css
+++ b/src/style/global.css
@@ -270,3 +270,9 @@ ul,
 ol {
     padding-inline-start: 1rem;
 }
+
+figure,
+image,
+img {
+    max-width: 100%;
+}


### PR DESCRIPTION
Ao adicionar uma imagem muito grande no post, o elemento transbordava para foras dos limites definidos. Mas agora foi adiciona uma largura máxima de 100% para que as imagens se limitem à largura do elemento pai

```css
figure,
image,
img {
    max-width: 100%;
}
```

### 📌 Exemplo

**Antes:**

<img width="1913" height="1078" alt="image_overflow" src="https://github.com/user-attachments/assets/3999800e-9df4-4c1e-aebc-606d656fb3c3" />

**Agora:**

<img width="1889" height="1012" alt="image_overflow_fixed" src="https://github.com/user-attachments/assets/2b929abf-2f77-4cc6-87fe-303528435cff" />

